### PR TITLE
Renderでの初回デプロイの設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,20 +82,5 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary: &primary_production
-    <<: *default
-    database: app_production
-    username: app
-    password: <%= ENV["APP_DATABASE_PASSWORD"] %>
-  cache:
-    <<: *primary_production
-    database: app_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: app_production_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    database: app_production_cable
-    migrations_paths: db/cable_migrate
+  url: <%= ENV['DATABASE_URL'] %>
+


### PR DESCRIPTION
Render で のデプロイでhost: db を読みに行って失敗したため、
database.ymlの<<: *defaultを削除

[参考](https://qiita.com/koki_73/items/60b327a586129d157f38)
[公式](https://render.com/docs/your-first-deploy#connect-a-datastore)
Close #39 