### PR TITLE
テストで current_user が nil になる問題を解消

### DIFF
--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,10 +1,11 @@
 require "test_helper"
-  setup do
-    @user = users(:one)
-  end
+
 
 
 class DashboardControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
   test "should get show" do
     sign_in @user
     get dashboard_show_url

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,3 +14,7 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
   end
 end
+
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end


### PR DESCRIPTION
test/controllers/dashboard_controller_test.rbにおいて、 
setupをクラスの外で呼び出していたため、クラスの中で定義するように修正