### PR TITLE
TODO編集機能の追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,7 +33,6 @@ class TasksController < ApplicationController
         flash.now[:alert] = @task.errors.full_messages
         render :edit, status: :unprocessable_entity
     end
-    end
   end
 
   def destroy

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,9 +16,9 @@ class TasksController < ApplicationController
   def create
     @task = current_user.tasks.new(task_params)
     if @task.save
-        redirect_to dashboard_show_path, notice: "タスクを作成しました"
+        redirect_to dashboard_show_path, notice: "TODOを作成しました"
     else
-        flash.now[:alert] = @task.errors.full_messages.join(", ")
+        flash.now[:alert] = @task.errors.full_messages
         render :new, status: :unprocessable_entity
     end
   end
@@ -27,6 +27,13 @@ class TasksController < ApplicationController
   end
 
   def update
+    if @task.update(task_params)
+        redirect_to dashboard_show_path, notice: "TODOを更新しました"
+    else
+        flash.now[:alert] = @task.errors.full_messages
+        render :edit, status: :unprocessable_entity
+    end
+    end
   end
 
   def destroy

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -49,14 +49,11 @@
                 bg-lime-400 hover:bg-lime-500/90
                 transition focus:outline-none focus:ring-lime-800" %>
 
-    <button type="button" disabled
-        class="inline-flex items-center justify-center rounded-full px-10 py-3
-                font-bold text-white shadow-sm
-                bg-rose-600 hover:bg-rose-400/90
-                ring-2 ring-rose-300
-                transition focus:outline-none focus:ring-rose-800
-                disabled:opacity-50 disabled:cursor-not-allowed">
-      削除
-    </button>
+    <% if task.persisted? %>
+      <%= button_to "削除", dashboard_show_path,
+          method: :delete,
+          data: { confirm: "本当に削除しますか？" },
+          class: "bg-red-400 text-white font-bold px-6 py-2 rounded-full hover:bg-red-500" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/tasks/_task_item.html.erb
+++ b/app/views/tasks/_task_item.html.erb
@@ -1,30 +1,34 @@
-<%= content_tag :li,
-  class: "mb-3 last:mb-0" do %>
-  <div class="flex items-center justify-between rounded-2xl bg-white shadow-sm ring-1 ring-black/5 px-5 py-4 hover:shadow md:px-6">
-    <!-- 左：タイトル-->
-    <div class="min-w-0">
-      <div class="text-lg font-semibold text-gray-900 truncate">
-        <%= t.title %>
+<%= content_tag :li, class: "mb-3 last:mb-0" do %>
+  <%= link_to edit_task_path(t),
+              class: "block rounded-2xl bg-white shadow-sm ring-1 ring-black/5 px-5 py-4 hover:shadow md:px-6" do %>
+    <div class="flex items-center justify-between">
+      <!-- 左：タイトル-->
+      <div class="min-w-0">
+        <div class="text-lg font-semibold text-gray-900 truncate">
+          <%= t.title %>
+        </div>
+      </div>
+
+      <!-- 中央：タグ -->
+      <% if t.respond_to?(:tag) && t.tag.present? %>
+        <span class="mx-4 hidden whitespace-nowrap rounded-lg bg-pink-50 px-3 py-1 text-xs font-bold tracking-wider text-pink-500 md:inline-block">
+          <%= t.tag %>
+        </span>
+      <% end %>
+
+      <!-- 右：チェックボックス-->
+      <div class="shrink-0">
+        <%= form_with model: t, url: task_path(t), method: :patch, html: { class: "inline-block" }, data: { turbo: false }  do |f| %>
+          <%= f.check_box :status,
+              { class: "h-9 w-9 rounded-lg border-2 border-gray-300
+                        text-green-500 focus:ring-2 focus:ring-green-400",
+                onclick: "event.stopPropagation(); this.form.submit();"
+              },
+              "done",
+              "open"
+          %>
+        <% end %>
       </div>
     </div>
-
-    <!-- 中央：タグ -->
-    <% if t.respond_to?(:tag) && t.tag.present? %>
-      <span class="mx-4 hidden whitespace-nowrap rounded-lg bg-pink-50 px-3 py-1 text-xs font-bold tracking-wider text-pink-500 md:inline-block">
-        <%= t.tag %>
-      </span>
-    <% end %>
-
-    <!-- 右：チェックボックス or アイコン -->
-    <div class="shrink-0">
-      <%= form_with model: t, url: "#", method: :patch, html: { class: "inline-block" } do |f| %>
-        <%= f.check_box :status,
-            { class: "h-9 w-9 rounded-lg border-2 border-gray-300
-                      text-green-500 focus:ring-2 focus:ring-green-400" },
-            "done",  # チェックされたときの値
-            "open"   # チェックされていないときの値
-        %>
-      <% end %>
-    </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,12 @@
+<div class="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+  <div class="bg-white rounded-xl shadow-xl w-full max-w-lg p-6">
+    <div class="flex items-center justify-between border-b pb-3 mb-4">
+      <h2 class="text-xl font-bold text-gray-800">TODOの編集</h2>
+      <%= link_to "×", root_path,
+        class: "text-gray-400 hover:text-gray-600 text-2xl leading-none",
+        "aria-label": "閉じる" %>
+    </div>
+
+    <%= render "form", task: @task %>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
TODO編集機能の追加

## 対応内容
- Close #7 
- updateアクションを定義
- /view/tasks/edit.html.erbの作成
- /view/tasks/_task_item.html.erbにおいて、タスクのエリアをクリックすると編集画面に遷移
（ただし、チェックボックスのチェック時はイベントの発火を event.stopPropagation();で止め、method: :patchとした
- /views/tasks/_form.html.erbの削除ボタンにif task.persisted?を追加し、編集時のみ表示
