### PR TITLE
TODO削除機能の実装

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -36,6 +36,11 @@ class TasksController < ApplicationController
   end
 
   def destroy
+    if @task.destroy
+        redirect_to dashboard_show_path, notice: "TODOを削除しました"
+    else
+        flash.now[:alert] = "TODOを削除できませんでした"
+        render :edit, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -41,6 +41,7 @@ class TasksController < ApplicationController
     else
         flash.now[:alert] = "TODOを削除できませんでした"
         render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -50,10 +50,9 @@
                 transition focus:outline-none focus:ring-lime-800" %>
 
     <% if task.persisted? %>
-      <%= button_to "削除", dashboard_show_path,
-          method: :delete,
-          data: { confirm: "本当に削除しますか？" },
-          class: "bg-red-400 text-white font-bold px-6 py-2 rounded-full hover:bg-red-500" %>
+      <%= link_to "削除", task_path(@task),
+          data: {  turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+          class: "bg-red-400 text-white font-bold px-10 py-3 rounded-full hover:bg-red-500" %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要
TODO削除機能の実装

## 対応内容
- Close #8 
- destroyアクションの定義
- 削除ボタンを以下の通り修正
`button_to `→ `link_to`
`method: :delete` → `turbo_method: :delete`

## 動作確認
1. ブラウザで タスクを削除
