### PR TITLE
レベルアップ機能の実装

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -13,7 +13,7 @@ class Character < ApplicationRecord
   def self.threshold_exp_for_next_level(level)
     return 0 if level < 1
     # レベルが上がるごとに値が1.2倍される
-    (100 * (1.2 ** (level - 1))).to_i
+    (1..level).sum { |n| (100 * 1.2**(n - 1)).to_i }
   end
   # 現在のレベルに到達するのに必要だった累計経験値
   def exp_floor
@@ -41,7 +41,7 @@ class Character < ApplicationRecord
   end
 
   # 経験値加算の処理の入り口
-  def gain_exp(amount)
+  def gain_exp!(amount)
     return if amount <= 0
     with_lock do
       self.exp += amount

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -39,4 +39,21 @@ class Character < ApplicationRecord
   def exp_progress_percentage
     ((current_level_exp.to_f/(exp_ceiling - exp_floor)) * 100).round
   end
+
+  # 経験値加算の処理の入り口
+  def gain_exp(amount)
+    return if amount <= 0
+    with_lock do
+      self.exp += amount
+      check_level_up
+      save!
+    end
+  end
+
+  # レベルアップ判定と処理
+  def check_level_up
+    while exp >= exp_ceiling
+      self.level += 1
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -37,7 +37,7 @@ class Task < ApplicationRecord
   def give_exp_to_active_character
     character = user.active_character
     return unless character.present?
-    # 経験値を加算
-    character.increment!(:exp, reward_exp)
+    # 経験値を加算(Characterモデルのgain_expメソッドを呼び出し)
+    character.gain_exp!(reward_exp)
   end
 end

--- a/app/views/characters/_status.html.erb
+++ b/app/views/characters/_status.html.erb
@@ -1,11 +1,16 @@
-<div id="exp_bar" class="w-full">
+<div id="character_status" class="w-full">
+
+  <!-- レベル表示 -->
+  <div class="text-lm text-gray-500">Lv. <%= character.level %></div>
+
+  <!-- 経験値ゲージ -->
+  <p>経験値</p>
   <div class="w-full bg-gray-200 rounded-full h-4">
     <div class="bg-green-500 h-4 rounded-full "
          style="width: <%= character.exp_progress_percentage %>%;">
     </div>
   </div>
-  
-  <!-- 残り経験値 -->
+  <!-- 次のレベルまでの経験値 -->
   <p class="mt-2 text-sm text-gray-600 text-right">
     次のレベルまであと <%= character.exp_needed %> EXP
   </p>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -11,8 +11,7 @@
     <h1>キャラクター</h1>
     <% if current_user.active_character %>
       <div class="ml-auto w-1/2">
-        <p>経験値</p>
-        <%= render "characters/exp_bar", character: current_user.active_character %>
+        <%= render "characters/status", character: current_user.active_character %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/complete.turbo_stream.erb
+++ b/app/views/tasks/complete.turbo_stream.erb
@@ -2,6 +2,6 @@
   <%= render "tasks/task_item", t: @task %>
 <% end %>
 
-<%= turbo_stream.replace "exp_bar" do %>
-  <%= render "characters/exp_bar", character: current_user.active_character %>
+<%= turbo_stream.replace "character_status" do %>
+  <%= render "characters/status", character: current_user.active_character %>
 <% end %>


### PR DESCRIPTION
## 概要
レベルアップ機能を実装

## 対応内容
- Close #42 
- Characterモデルに 経験値加算のメソッドとレベルルアップ判定・処理のメソッドを定義
- 上記で定義した経験値加算のメソッドをTaskモデルで呼び出し
→これまでTaskモデル側で経験値expのUPDATEをしていたが、これだとレベルアップ処理が飛ばされる可能性があるので、Taskモデルでは呼び出すだけにする
- 経験値表示とレベル表示を同じパーシャルにまとめて、Ajax化

## 動作確認
1. ブラウザで タスクを完了にし、次のレベルまでの経験値を獲得するとゲージがリセットされレベルが１上がっていることを確認
