### PR TITLE
LINE 通知設定の追加

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -4,4 +4,7 @@ class SettingsController < ApplicationController
   def show
     @user = current_user
   end
+
+  def line_settings
+  end
 end

--- a/app/views/settings/line_settings.html.erb
+++ b/app/views/settings/line_settings.html.erb
@@ -1,0 +1,32 @@
+<div class="max-w-3xl mx-4 md:mx-20 p-4 md:p-6">
+    <div class="bg-gradient-to-r from-[#00C300] via-[#00B900] to-[#009A00] rounded-xl p-4 md:p-5 shadow-md">
+        <div class="flex items-center justify-center">
+            <h1 class="text-lg md:text-2xl font-semibold text-white text-center">LINE通知設定</h1>
+        </div>
+    </div>
+
+    <!-- 友だち追加カード -->
+    <div class="bg-white border border-gray-100 rounded-xl p-4 md:p-6 shadow-lg">
+        <div class="flex flex-col md:flex-row items-center justify-center gap-4 text-center">
+            <div class="w-full">
+                <p class="my-4 md:my-6 text-xs md:text-sm text-gray-600 text-center">
+                    TODOに設定した期限の前日になるとLINEで通知が届きます。<br>
+                    LINE通知を有効にするには、以下のボタンから「モチペット」公式LINEを友だち追加してください。
+                </p>
+            </div>
+        </div>
+
+        <div class="mt-4">
+            <!-- LINE 友だち追加ボタン -->
+            <div class="mb-4 flex items-center justify-center">
+                <div class="line-it-wrapper inline-block transform scale-125 md:scale-150 origin-center">
+                    <div class="line-it-button" data-lang="ja" data-type="friend" data-env="PROD" data-lineId="&#64;644ouadb" style="display: none;"></div>
+                </div>
+
+                <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
+            </div>
+
+            <p class="text-xs md:text-sm text-gray-500">ボタンが機能しない場合は、LINEで「&#64;644ouadb」を検索して友だち追加してください。</p>
+        </div>
+    </div>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,29 +1,100 @@
-<div class="max-w-md mx-auto py-12 px-4">
-  <h1 class="text-2xl font-bold mb-8 text-center">設定</h1>
-  <ul class="space-y-4">
-    <li>
-      <%= link_to 'ユーザー情報', profile_path,
-        class: "text-lg text-gray-800 underline hover:text-blue-600 transition" %>
-    </li>
-    <li>
-      <%= link_to 'LINE通知', "#",
-        class: "text-lg text-gray-800 underline hover:text-blue-600 transition" %>
-    </li>
-    <li>
-      <%= link_to '外部アプリ連携', "#",
-        class: "text-lg text-gray-800 underline hover:text-blue-600 transition" %>
-    </li>
-    <li>
-      <%= link_to '使い方', root_path,
-        class: "text-lg text-gray-800 underline hover:text-blue-600 transition" %>
-    </li>
-    <li>
-      <%= link_to 'プライバシーポリシー', "#",
-        class: "text-lg text-gray-800 underline hover:text-blue-600 transition" %>
-    </li>
-    <li>
-      <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete },
-        class: "block w-full rounded-lg bg-red-100 px-6 py-4 text-lg font-semibold text-red-700 hover:bg-red-200 transition" %>
-    </li>
-  </ul>
+<div class="max-w-xl mx-auto py-12 px-4">
+  <div class="bg-gradient-to-br from-white to-gray-50 rounded-2xl shadow-lg ring-1 ring-gray-100 overflow-hidden">
+    <div class="px-6 py-8 ">
+      <h1 class="text-3xl font-extrabold mb-2 bg-clip-text ">
+        設定
+      </h1>
+    </div>
+
+    <ul class="divide-y divide-gray-100">
+      <li>
+        <%= link_to profile_path, class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50 transition" do %>
+          <div class="flex items-center gap-4">
+            <div class="flex-none w-10 h-10 rounded-lg bg-indigo-50 text-indigo-600 flex items-center justify-center">
+              <!-- user icon -->
+              <i class="fa-regular fa-circle-user mb-1"></i>
+            </div>
+            <div>
+              <div class="text-lg font-medium text-gray-800">ユーザー情報</div>
+              <div class="text-sm text-gray-400">プロフィールやメール設定</div>
+            </div>
+          </div>
+          <svg class="w-5 h-5 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        <% end %>
+      </li>
+
+      <li>
+        <%= link_to line_settings_path, class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50 transition" do %>
+          <div class="flex items-center gap-4">
+            <div class="flex-none w-10 h-10 rounded-lg bg-green-50 text-green-600 flex items-center justify-center">
+              <!-- bell icon -->
+              <i class="fa-regular fa-bell"></i>
+            </div>
+            <div>
+              <div class="text-lg font-medium text-gray-800">LINE通知</div>
+              <div class="text-sm text-gray-400">通知の受信設定</div>
+            </div>
+          </div>
+          <svg class="w-5 h-5 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        <% end %>
+      </li>
+
+      <li>
+        <%= link_to "#", class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50 transition" do %>
+          <div class="flex items-center gap-4">
+            <div class="flex-none w-10 h-10 rounded-lg bg-yellow-50 text-yellow-600 flex items-center justify-center">
+              <!-- plug icon -->
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 7V3m-4 4V3m-4 8h12v6a2 2 0 01-2 2H8a2 2 0 01-2-2v-6z"/></svg>
+            </div>
+            <div>
+              <div class="text-lg font-medium text-gray-800 flex items-center gap-2">
+                外部アプリ連携
+              </div>
+              <div class="text-sm text-gray-400">サードパーティサービスの連携</div>
+            </div>
+          </div>
+          <svg class="w-5 h-5 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        <% end %>
+      </li>
+
+      <li>
+        <%= link_to root_path, class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50 transition" do %>
+          <div class="flex items-center gap-4">
+            <div class="flex-none w-10 h-10 rounded-lg bg-blue-50 text-blue-600 flex items-center justify-center">
+              <!-- book icon -->
+              <i class="fa-regular fa-file"></i>
+            </div>
+            <div>
+              <div class="text-lg font-medium text-gray-800">使い方</div>
+              <div class="text-sm text-gray-400">基本的な操作ガイド</div>
+            </div>
+          </div>
+          <svg class="w-5 h-5 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        <% end %>
+      </li>
+
+      <li>
+        <%= link_to "#", class: "flex items-center justify-between gap-4 px-6 py-4 hover:bg-gray-50 transition" do %>
+          <div class="flex items-center gap-4">
+            <div class="flex-none w-10 h-10 rounded-lg bg-gray-50 text-gray-600 flex items-center justify-center">
+              <!-- lock icon -->
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+            </div>
+            <div>
+              <div class="text-lg font-medium text-gray-800">プライバシーポリシー</div>
+              <div class="text-sm text-gray-400">データの取り扱いについて</div>
+            </div>
+          </div>
+          <svg class="w-5 h-5 text-gray-300" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        <% end %>
+      </li>
+
+      <li class="px-6 py-6">
+        <%= link_to destroy_user_session_path, data: { turbo_method: :delete }, class: "w-full inline-flex items-center justify-center gap-3 rounded-lg bg-gradient-to-r from-red-500 to-rose-500 text-white font-semibold px-5 py-3 hover:from-red-600 hover:to-rose-600 shadow-md transition" do %>
+          <svg class="w-5 h-5 text-white/90" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8v8"/></svg>
+          ログアウト
+        <% end %>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,11 @@ Rails.application.routes.draw do
 
   resource :charts, only: [ :show ]
 
-  resource :settings, only: [ :show ]
+  # Line通知設定画面用のルーティング追加
+  resource :settings, only: [ :show ] do
+    # Line設定の表示・編集・更新
+    get "line", to: "settings#line_settings"
+  end
 
   resource :profile, only: [ :show ]
 


### PR DESCRIPTION
概要
LINE通知を利用するには、公式LINE Botを友だち追加する必要があるため、
LINE通知の設定画面に公式LINEを友だち追加ボタンを追加

対応内容
	•	LINE通知設定を管理するための新しい「LINE通知設定」ページを追加
	•	公式LINEアカウントの友だち追加ボタンを追加
	•	settings/show.html.erb （設定画面）のデザインを更新


動作確認
	1.	ログイン後、設定画面にアクセスする
	2.	設定一覧に「LINE通知設定」が表示されていることを確認
	3.	「LINE通知設定」をクリックし、専用ページが表示されることを確認
	4.	LINE通知の説明文と「友だち追加」ボタンが表示されていることを確認

参考資料
	•	[LINE Messaging API 公式ドキュメント](https://developers.line.biz/ja/docs/messaging-api/)￼

