### PR TITLE
DatabaseCleanerをtest環境のみで実行するように修正

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,23 +1,35 @@
 require 'database_cleaner/active_record'
 
-RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-  end
+# test環境でのみDatabaseCleanerを有効化
+# development/production環境でのデータ削除を防ぐ
+if Rails.env.test?
+  RSpec.configure do |config|
+    config.before(:suite) do
+      DatabaseCleaner.clean_with(:truncation)
+    end
 
-  config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
+    config.before(:each) do
+      DatabaseCleaner.strategy = :transaction
+    end
 
-  config.before(:each, type: :system) do
-    DatabaseCleaner.strategy = :truncation
-  end
+    config.before(:each, type: :system) do
+      DatabaseCleaner.strategy = :truncation
+    end
 
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
+    config.before(:each) do
+      DatabaseCleaner.start
+    end
 
-  config.after(:each) do
-    DatabaseCleaner.clean
+    config.after(:each) do
+      DatabaseCleaner.clean
+    end
+  end
+else
+  # test環境以外で実行された場合は警告を表示
+  RSpec.configure do |config|
+    config.before(:suite) do
+      puts "\n⚠️  WARNING: RSpec is running in #{Rails.env} environment!"
+      puts "   DatabaseCleaner is DISABLED to protect your data.\n\n"
+    end
   end
 end


### PR DESCRIPTION
## 概要
RSpec実行時にDatabaseCleanerが開発環境のデータベースをクリーンアップしてしまう問題を修正しました。

## 対応内容
- `spec/support/database_cleaner.rb` に `Rails.env.test?` チェックを追加
- test環境以外でRSpecを実行した場合は警告メッセージを表示
- development/production環境のデータベースを保護

## 動作確認
1. development環境でRSpecを実行 → 警告メッセージが表示され、DatabaseCleanerは無効化される
2. test環境でRSpecを実行 → DatabaseCleanerが正常に動作し、テストがパスする
3. development DBのデータが保護されることを確認（Users: 3件、CharacterKinds: 14件が保持）

## 参考資料
- [DatabaseCleaner公式ドキュメント](https://github.com/DatabaseCleaner/database_cleaner)