### PR TITLE
独自ドメイン（motipet.com）のホスト設定を追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,12 @@ module App
     config.active_job.queue_adapter = :sidekiq
     config.app_url = "https://mochipet.onrender.com/"
 
+    # 独自ドメイン設定
+    config.hosts << ".motipet.com"
+    config.hosts << "www.motipet.com"
+    config.hosts << "motipet.com"
+
+
     # テスト環境以外でhost authorizationを有効化
     unless Rails.env.test?
       config.hosts << ".example.com"


### PR DESCRIPTION
## 概要
独自ドメイン `motipet.com` を使用できるようにするため、Rails の Host Authorization 設定を追加しました。

## 変更内容
`config/application.rb` に以下のドメインを `config.hosts` に追加:
- `.motipet.com` (サブドメイン含む)
- `www.motipet.com`
- `motipet.com`

これにより、独自ドメインからのリクエストが Rails アプリケーションで正しく処理されるようになります。