### PR TITLE
LINE通知設定を本番環境用に調整

### DIFF
--- a/app/views/settings/line_settings.html.erb
+++ b/app/views/settings/line_settings.html.erb
@@ -26,7 +26,7 @@
                 <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
             </div>
 
-            <p class="text-xs md:text-sm text-gray-500">ボタンが機能しない場合は、LINEで「&#64;644ouadb」を検索して友だち追加してください。</p>
+            <p class="text-xs md:text-sm text-gray-500">ボタンが機能しない場合はリロード又は、LINEで「&#64;644ouadb」を検索して友だち追加してください。</p>
         </div>
     </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module App
 
     # sidekiq設定
     config.active_job.queue_adapter = :sidekiq
-    config.app_url = "https://mochipet.onrender.com/"
+    config.app_url = "https://www.motipet.com/"
 
     # 独自ドメイン設定
     config.hosts << ".motipet.com"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -17,6 +17,6 @@ tasks_daily_reset_habit_status: #ジョブの識別名
 tasks_due_line_notifications:
   class: "LineNotifyJob"
   queue: "default"
-  cron: "*/1 * * * *"
-  # cron: "0 9 * * *"
+  #cron: "*/1 * * * *"
+  cron: "0 9 * * *"
   timezone: "Asia/Tokyo"


### PR DESCRIPTION
## 概要
LINE通知機能を本番環境で正しく動作するように設定を調整しました。

## 変更内容

### 1. アプリURLを独自ドメインに変更
**ファイル**: `config/application.rb`
```ruby
# 変更前
config.app_url = "https://mochipet.onrender.com/"

# 変更後
config.app_url = "https://www.motipet.com/"
```
LINE通知メッセージ内のリンクが独自ドメインを指すようになります。

### 2. LINE通知のスケジュールを本番設定に変更
**ファイル**: `config/schedule.yml`
```yaml
# 変更前（テスト用: 1分おき）
cron: "*/1 * * * *"

# 変更後（本番用: 毎日9時）
cron: "0 9 * * *"
```
明日が期限のタスクを持つユーザーに、毎日朝9時にLINE通知が送られます。

### 3. LINE友だち追加ボタンの説明文を更新
**ファイル**: `app/views/settings/line_settings.html.erb`
- ボタンが初回表示されない問題の回避策として、「リロード」の案内を追加

## 既知の課題
LINE友だち追加ボタンが初回表示時に表示されず、リロードが必要になる問題があります。
詳細は #169 を参照してください。

## テスト方法
1. LINE通知設定画面（`/settings/line`）にアクセス
2. 友だち追加ボタンが表示されることを確認（表示されない場合はリロード）
3. 友だち追加後、明日が期限のタスクを作成
4. 翌朝9時にLINE通知が届くことを確認