### PR TITLE
refactor: ChartsControllerとビューをService Objectパターンでリファクタリング

### DIFF
--- a/app/controllers/charts_controller.rb
+++ b/app/controllers/charts_controller.rb
@@ -3,63 +3,27 @@ class ChartsController < ApplicationController
 
   def show
     # 日数パラメータ取得（7日 or 30日）
-    @days = (%w[7 30].include?(params[:range]) ? params[:range].to_i : 7)
-    range = @days.days.ago.to_date..Date.current
+    days = %w[7 30].include?(params[:range]) ? params[:range].to_i : 7
 
-    @tasks = current_user.tasks.order(created_at: :desc)
+    # 完了実績グラフ用データ
+    completion_data = Charts::CompletionChartService.new(user: current_user, days: days).call
+    @days = completion_data[:days]
+    @todo_completed = completion_data[:todo_completed]
+    @habit_done = completion_data[:habit_done]
+    @tasks = completion_data[:tasks]
 
-    # TODO完了数（日別）
-    @todo_completed = TaskEvent.where(user: current_user, task_kind: :todo, action: :completed)
-      .group_by_day(:occurred_at, range: range)
-      .count
+    # 習慣の数量ログデータ
+    habit_metrics = Charts::HabitMetricsService.new(user: current_user, days: 7).call
+    @task_meta = habit_metrics[:task_meta]
+    @series_by_task = habit_metrics[:series_by_task]
+    @total_by_task = habit_metrics[:total_by_task]
 
-    # 習慣完了・ログ数（日別）
-    @habit_done = TaskEvent.where(user: current_user, task_kind: :habit, action: [:completed, :logged])
-      .group_by_day(:occurred_at, range: range)
-      .count
-
-    # --- 習慣の数量ロググラフ用 ---
-    log_range = 7.days.ago.beginning_of_day..Time.zone.now
-
-    # ログ型習慣のTaskEvent
-    log_events = TaskEvent.where(user_id: current_user.id, task_kind: :habit, action: :logged, occurred_at: log_range)
-
-    # タスクメタ情報（タイトルはTaskテーブルから、単位は最新のTaskEventから取得）
-    task_ids = log_events.distinct.pluck(:task_id)
-    tasks = Task.where(id: task_ids).index_by(&:id)
-
-    # 各タスクの最新のログイベントのunitを一括取得（サブクエリで最新のoccurred_atを取得）
-    latest_event_units = TaskEvent
-      .where(user_id: current_user.id, task_kind: :habit, action: :logged, task_id: task_ids)
-      .select('DISTINCT ON (task_id) task_id, unit')
-      .order('task_id, occurred_at DESC')
-      .index_by(&:task_id)
-
-    @task_meta = task_ids.to_h do |tid|
-      task = tasks[tid]
-      latest_event = latest_event_units[tid]
-      unit = latest_event&.unit.presence || task&.target_unit.presence || "数量"
-
-      [tid, { title: task&.title || "不明なタスク", unit: unit }]
-    end
-
-    # 日別×タスクごとの合計値
-    raw = log_events.group_by_day(:occurred_at, range: log_range)
-      .group(:task_id)
-      .sum(:amount) # { [Date, task_id] => 合計 }
-
-    # 整形: { task_id => { date => 合計 } }
-    @series_by_task = Hash.new { |h, k| h[k] = {} }
-    raw.each do |(date, tid), sum|
-      @series_by_task[tid][date] = sum
-    end
-
-    # 全期間合計値
-    @total_by_task = log_events.group(:task_id).sum(:amount)
-
+    # カレンダーデータ
     raw_date = params[:start_date].present? ? Date.parse(params[:start_date]) : Time.zone.today
-    @start_date = raw_date.beginning_of_month
-    @all_events = current_user.task_events.where(action: :completed)
+    start_date = raw_date.beginning_of_month
+    calendar_data = Charts::CalendarDataService.new(user: current_user, start_date: start_date).call
+    @start_date = calendar_data[:start_date]
+    @all_events = calendar_data[:all_events]
 
     respond_to do |format|
       format.html

--- a/app/helpers/charts_helper.rb
+++ b/app/helpers/charts_helper.rb
@@ -1,2 +1,29 @@
+# frozen_string_literal: true
+
 module ChartsHelper
+  # グラフの共通設定を返す
+  def default_chart_library_options
+    {
+      chart: {
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        toolbar: { show: false }
+      },
+      dataLabels: { enabled: false },
+      stroke: { curve: "smooth", width: 3 }
+    }
+  end
+
+  # 習慣メトリック用の小さいグラフ設定
+  def habit_metric_chart_options
+    default_chart_library_options.merge(
+      chart: default_chart_library_options[:chart].merge(height: 140),
+      grid: {
+        show: true,
+        borderColor: "#f3f4f6",
+        strokeDashArray: 3
+      },
+      scales: { y: { beginAtZero: true } },
+      plugins: { legend: { display: false } }
+    )
+  end
 end

--- a/app/services/charts/calendar_data_service.rb
+++ b/app/services/charts/calendar_data_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Charts
+  # カレンダー表示用のデータを取得するサービス
+  class CalendarDataService
+    def initialize(user:, start_date:)
+      @user = user
+      @start_date = start_date
+    end
+
+    def call
+      {
+        start_date: @start_date,
+        all_events: fetch_events
+      }
+    end
+
+    private
+
+    def fetch_events
+      @user.task_events.where(action: :completed)
+    end
+  end
+end

--- a/app/services/charts/completion_chart_service.rb
+++ b/app/services/charts/completion_chart_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Charts
+  # TODO・習慣の完了実績グラフ用データを取得するサービス
+  class CompletionChartService
+    def initialize(user:, days: 7)
+      @user = user
+      @days = days
+    end
+
+    def call
+      {
+        days: @days,
+        todo_completed: fetch_todo_completed,
+        habit_done: fetch_habit_done,
+        tasks: fetch_tasks
+      }
+    end
+
+    private
+
+    def date_range
+      @date_range ||= @days.days.ago.to_date..Date.current
+    end
+
+    def fetch_todo_completed
+      TaskEvent.where(user: @user, task_kind: :todo, action: :completed)
+        .group_by_day(:occurred_at, range: date_range)
+        .count
+    end
+
+    def fetch_habit_done
+      TaskEvent.where(user: @user, task_kind: :habit, action: [:completed, :logged])
+        .group_by_day(:occurred_at, range: date_range)
+        .count
+    end
+
+    def fetch_tasks
+      @user.tasks.order(created_at: :desc)
+    end
+  end
+end

--- a/app/services/charts/habit_metrics_service.rb
+++ b/app/services/charts/habit_metrics_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Charts
+  # 習慣の数量ログデータを取得するサービス
+  class HabitMetricsService
+    def initialize(user:, days: 7)
+      @user = user
+      @days = days
+    end
+
+    def call
+      {
+        task_meta: task_metadata,
+        series_by_task: series_data,
+        total_by_task: total_data
+      }
+    end
+
+    private
+
+    def date_range
+      @date_range ||= @days.days.ago.beginning_of_day..Time.zone.now
+    end
+
+    def log_events
+      @log_events ||= TaskEvent.where(
+        user_id: @user.id,
+        task_kind: :habit,
+        action: :logged,
+        occurred_at: date_range
+      )
+    end
+
+    def task_ids
+      @task_ids ||= log_events.distinct.pluck(:task_id)
+    end
+
+    def tasks
+      @tasks ||= Task.where(id: task_ids).index_by(&:id)
+    end
+
+    # 各タスクの最新のログイベントのunitを一括取得
+    def latest_event_units
+      @latest_event_units ||= TaskEvent
+        .where(user_id: @user.id, task_kind: :habit, action: :logged, task_id: task_ids)
+        .select("DISTINCT ON (task_id) task_id, unit")
+        .order("task_id, occurred_at DESC")
+        .index_by(&:task_id)
+    end
+
+    def task_metadata
+      task_ids.to_h do |tid|
+        task = tasks[tid]
+        latest_event = latest_event_units[tid]
+        unit = latest_event&.unit.presence || task&.target_unit.presence || "数量"
+
+        [tid, { title: task&.title || "不明なタスク", unit: unit }]
+      end
+    end
+
+    def series_data
+      # 日別×タスクごとの合計値
+      raw = log_events.group_by_day(:occurred_at, range: date_range)
+        .group(:task_id)
+        .sum(:amount)
+
+      # 整形: { task_id => { date => 合計 } }
+      series = Hash.new { |h, k| h[k] = {} }
+      raw.each do |(date, tid), sum|
+        series[tid][date] = sum
+      end
+      series
+    end
+
+    def total_data
+      log_events.group(:task_id).sum(:amount)
+    end
+  end
+end

--- a/app/views/charts/_habit_metric_card.html.erb
+++ b/app/views/charts/_habit_metric_card.html.erb
@@ -1,0 +1,45 @@
+<%
+# 習慣メトリックカードのパーシャル
+# @param tid [Integer] タスクID
+# @param meta [Hash] タスクメタデータ { title:, unit: }
+# @param series [Hash] 日別データ { date => value }
+# @param total [Numeric] 合計値
+%>
+<div class="group/card relative">
+  <div class="absolute -inset-0.5 bg-gradient-to-br from-yellow-200/60 to-yellow-300/60 rounded-2xl blur opacity-0 group-hover/card:opacity-20 transition duration-500"></div>
+  <div class="relative bg-white rounded-2xl border border-yellow-100/50 overflow-hidden shadow-md hover:shadow-lg transition-all duration-300">
+
+    <!-- Card Header with Stat -->
+    <div class="relative bg-gradient-to-br from-yellow-50 to-yellow-100/50 px-5 py-4 border-b border-yellow-100/50">
+      <div class="flex items-start justify-between gap-3 mb-3">
+        <h3 class="font-black text-gray-900 text-base leading-tight flex-1 line-clamp-2">
+          <%= meta[:title] %>
+        </h3>
+      </div>
+
+      <!-- Large Stat Display -->
+      <div class="flex items-end gap-2">
+        <div class="relative">
+          <div class="absolute inset-0 bg-gradient-to-br from-yellow-300 to-yellow-400 blur-sm opacity-15"></div>
+          <div class="relative text-5xl font-black bg-gradient-to-br from-yellow-600 to-yellow-700 bg-clip-text text-transparent tabular-nums">
+            <%= total %>
+          </div>
+        </div>
+        <div class="text-xs font-bold text-gray-500 mb-2">
+          <%= t("enums.task.target_unit.#{meta[:unit]}", default: meta[:unit]) %>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mini Chart -->
+    <div class="p-4 bg-white">
+      <%= column_chart series,
+            xtitle: "",
+            ytitle: "",
+            points: false,
+            curve: true,
+            colors: ["#eab308"],
+            library: habit_metric_chart_options %>
+    </div>
+  </div>
+</div>

--- a/app/views/charts/show.html.erb
+++ b/app/views/charts/show.html.erb
@@ -74,14 +74,7 @@
                     ],
                     xtitle: "日付",
                     ytitle: "完了数",
-                    library: {
-                      chart: {
-                        fontFamily: 'system-ui, -apple-system, sans-serif',
-                        toolbar: { show: false }
-                      },
-                      dataLabels: { enabled: false },
-                      stroke: { curve: 'smooth', width: 3 }
-                    } %>
+                    library: default_chart_library_options %>
               </div>
             </div>
           </div>
@@ -116,59 +109,8 @@
                 <% meta = @task_meta[tid] || { title: "不明なタスク", unit: "数量" } %>
                 <% total = @total_by_task[tid] || 0 %>
 
-                <!-- Metric Card -->
-                <div class="group/card relative">
-                  <div class="absolute -inset-0.5 bg-gradient-to-br from-yellow-200/60 to-yellow-300/60 rounded-2xl blur opacity-0 group-hover/card:opacity-20 transition duration-500"></div>
-                  <div class="relative bg-white rounded-2xl border border-yellow-100/50 overflow-hidden shadow-md hover:shadow-lg transition-all duration-300">
-                    <!-- Card Header with Stat -->
-                    <div class="relative bg-gradient-to-br from-yellow-50 to-yellow-100/50 px-5 py-4 border-b border-yellow-100/50">
-                      <div class="flex items-start justify-between gap-3 mb-3">
-                        <h3 class="font-black text-gray-900 text-base leading-tight flex-1 line-clamp-2">
-                          <%= meta[:title] %>
-                        </h3>
-                      </div>
-
-                      <!-- Large Stat Display -->
-                      <div class="flex items-end gap-2">
-                        <div class="relative">
-                          <div class="absolute inset-0 bg-gradient-to-br from-yellow-300 to-yellow-400 blur-sm opacity-15"></div>
-                          <div class="relative text-5xl font-black bg-gradient-to-br from-yellow-600 to-yellow-700 bg-clip-text text-transparent tabular-nums">
-                            <%= total %>
-                          </div>
-                        </div>
-                        <div class="text-xs font-bold text-gray-500 mb-2">
-                          <%= t("enums.task.target_unit.#{meta[:unit]}", default: meta[:unit]) %>
-                        </div>
-                      </div>
-                    </div>
-
-                    <!-- Mini Chart -->
-                    <div class="p-4 bg-white">
-                      <%= column_chart series,
-                            xtitle: "",
-                            ytitle: "",
-                            points: false,
-                            curve: true,
-                            colors: ["#eab308"],
-                            library: {
-                              chart: {
-                                fontFamily: 'system-ui, -apple-system, sans-serif',
-                                toolbar: { show: false },
-                                height: 140
-                              },
-                              dataLabels: { enabled: false },
-                              grid: {
-                                show: true,
-                                borderColor: '#f3f4f6',
-                                strokeDashArray: 3
-                              },
-                              scales: { y: { beginAtZero: true } },
-                              plugins: { legend: { display: false } },
-                              stroke: { curve: 'smooth', width: 3 }
-                            } %>
-                    </div>
-                  </div>
-                </div>
+                <%= render partial: "habit_metric_card",
+                           locals: { tid: tid, meta: meta, series: series, total: total } %>
               <% end %>
             </div>
           <% else %>


### PR DESCRIPTION
## 概要
ChartsControllerの複雑性を軽減するため、Service Objectパターンを適用してリファクタリング

## 変更内容

###  コントローラー（ChartsController）
- データ取得ロジックを3つのサービスクラスに分離
  - `Charts::CalendarDataService` - カレンダー表示用データ取得
  - `Charts::CompletionChartService` - TODO/習慣の完了実績グラフ用データ取得
  - `Charts::HabitMetricsService` - 習慣の数量ログデータ取得

###  ビュー（show.html.erb）
- 習慣メトリックカードをパーシャル化（`_habit_metric_card.html.erb`）
- 繰り返しコードを削減

###  ヘルパー（ChartsHelper）
- グラフ設定を共通化するヘルパーメソッドを追加
  - `default_chart_library_options` - 完了実績グラフ用の設定
  - `habit_metric_chart_options` - 習慣メトリックグラフ用の設定
